### PR TITLE
Ignore convertion to float for some properties

### DIFF
--- a/coolbox/utilities/__init__.py
+++ b/coolbox/utilities/__init__.py
@@ -37,7 +37,7 @@ BUILT_IN_GENOMES = {
 
 FEATURES_STACK_NAME = "__COOLBOX_FEATURE_STACK__"
 COVERAGE_STACK_NAME = "__COOLBOX_COVERAGE_STACK__"
-
+IGNORE_TYPE_CHANGE = ['title','name']
 
 def get_feature_stack():
     global_scope = globals()
@@ -60,6 +60,8 @@ def format_properties(properties):
         if isinstance(value, bool):
             properties[key] = 'yes' if value else 'no'
         elif isinstance(value, str):
+            if key in IGNORE_TYPE_CHANGE:
+                continue
             try:
                 float_val = float(value)
                 properties[key] = float_val


### PR DESCRIPTION
Hi @Nanguage ,

If a track title (which is normally of type str) can be interpreted as number, it is cast to float.
However, I thought that certain properties, could just be used as they are without the conversion. 
For instance, I am working on an application in which the track titles should be integer numbers.

Unless this is specifically your intention, I'd suggest to restrict the type conversion to specific
properties and/or black-list certain properties from being converted even if that would be possible.

Let me know if this makes sense to you.
Perhaps it needs to be generalized more broadly.
Currently it only ignores type conversion for "title" and "name".

Best,
@wkopp