### PR TITLE
Reset file_handle to avoid skipping the first interval for visualization

### DIFF
--- a/coolbox/core/track/bed/fetch.py
+++ b/coolbox/core/track/bed/fetch.py
@@ -34,6 +34,7 @@ class FetchBed(object):
         intervals = []
         try:
             bed_iterator = ReadBed(query_bed(bgz_file, gr.chrom, gr.start, gr.end))
+            bed_iterator.file_handle = query_bed(bgz_file, gr.chrom, gr.start, gr.end)
         except StopIteration:
             log.info(f"No records in the range {str(gr)}")
             return [], None


### PR DESCRIPTION
Hi, 
I noticed that when visualizing intervals from bed files,
the first interval is missed and not visualized.

The issue is located in `ReadBed`.

The `ReadBed` constructor receives a generator `file_handle`
which is later consumed in the `__next__` method to assemble the list of
intervals for the visualization.
However, in the constructor, the first element of the `file_handle` is already
consumed for the purpose of guessing the file type (within the `self.get_no_comment_line()` call).
Because of that, this first interval is missed for the visualization.

I added a quick (though not very elegant) fix for this issue, by simply re-creating the generator `file_handle`
again directly after `ReadBed` has been constructed.

If you are aware of a more elegant way to fix this issue and if I can help with implementing it, let me know.

Best,
@wkopp 