### PR TITLE
Staircase plot style for Hist

### DIFF
--- a/coolbox/core/track/hist/plot.py
+++ b/coolbox/core/track/hist/plot.py
@@ -85,11 +85,15 @@ class PlotHist(object):
         alpha = self.properties.get("alpha", 1.0)
         threshold = float(self.properties.get("threshold"))
         threshold_color = self.properties.get("threshold_color")
-        ax.stairs(edges=edges, values=values, linewidth=line_width, color=color, alpha=alpha, fill=fill)
         if threshold and np.sum(values > threshold) > 0:
+            masked_values = values.copy()
+            masked_values[masked_values > threshold] = np.nan
+            ax.stairs(edges=edges, values=masked_values, linewidth=line_width, color=color, alpha=alpha, fill=fill)
             masked_values = values.copy()
             masked_values[masked_values <= threshold] = np.nan
             ax.stairs(edges=edges, values=masked_values, linewidth=line_width, color=threshold_color, alpha=alpha, fill=fill)
+        else:
+            ax.stairs(edges=edges, values=values, linewidth=line_width, color=color, alpha=alpha, fill=fill)
 
     def plot_data_range(self, ax, ymin, ymax, data_range_style, gr: GenomeRange):
         if data_range_style == 'text':

--- a/coolbox/core/track/hist/plot.py
+++ b/coolbox/core/track/hist/plot.py
@@ -14,6 +14,10 @@ class PlotHist(object):
         style = self.properties.get('style', 'line')
         if 'heatmap' in style:
             self.plot_heatmap(ax, gr, values)
+        elif 'stairsfilled' in style:
+            self.plot_stairs(ax, gr, values, fill=True)
+        elif 'stairs' in style:
+            self.plot_stairs(ax, gr, values, fill=False)
         elif 'fill' in style:
             self.plot_fill(ax, indexes, values)
         elif 'scatter' in style:
@@ -71,6 +75,21 @@ class PlotHist(object):
         if threshold and np.sum(values > threshold) > 0:
             masked_values = np.ma.masked_greater_equal(values, threshold)
             ax.plot(indexes, masked_values, fmt, linewidth=line_width, color=threshold_color, alpha=alpha)
+
+    def plot_stairs(self, ax, gr, values, fill=True):
+        if len(values.shape) == 2:
+            values = values.T
+        edges = np.linspace(gr.start, gr.end, values.shape[0] + 1)
+        line_width = self.properties.get('line_width', 1)
+        color = self.properties.get('color')
+        alpha = self.properties.get("alpha", 1.0)
+        threshold = float(self.properties.get("threshold"))
+        threshold_color = self.properties.get("threshold_color")
+        ax.stairs(edges=edges, values=values, linewidth=line_width, color=color, alpha=alpha, fill=fill)
+        if threshold and np.sum(values > threshold) > 0:
+            masked_values = values.copy()
+            masked_values[masked_values <= threshold] = np.nan
+            ax.stairs(edges=edges, values=masked_values, linewidth=line_width, color=threshold_color, alpha=alpha, fill=fill)
 
     def plot_data_range(self, ax, ymin, ymax, data_range_style, gr: GenomeRange):
         if data_range_style == 'text':


### PR DESCRIPTION
Adds two new plotting styles: `stairs` and `stairsfilled`. It provides nicer rendering of interval-supported scores. Uses `plt.stairs` which requires [matplotlib 3.4](https://matplotlib.org/stable/users/whats_new.html#new-stairs-method-and-steppatch-artist).

```python
from coolbox import XAxis, BigWig

frame = (
    XAxis() + 
    BigWig('tests/test_data/bigwig_chr9_4000000_6000000.bw', threshold=200) + 
    BigWig('tests/test_data/bigwig_chr9_4000000_6000000.bw', threshold=200, style='stairsfilled')
)

frame.plot("chr9:5600000-6000000")
````

![image](https://user-images.githubusercontent.com/1270651/114122353-19439600-98be-11eb-8de4-fc309e2795fe.png)

