### PR TITLE
Toggleable pixel matrix aspect ratio

### DIFF
--- a/coolbox/core/frame/frame.py
+++ b/coolbox/core/frame/frame.py
@@ -196,8 +196,7 @@ class Frame(FrameBase):
         grids = matplotlib.gridspec.GridSpec(
             len(tracks_height), 3,
             height_ratios=tracks_height,
-            width_ratios=self.properties['width_ratios'],
-            wspace=0.01)
+            width_ratios=self.properties['width_ratios'])
 
         axis_list = []
         for idx, track in enumerate(self.tracks.values()):

--- a/coolbox/core/frame/frame.py
+++ b/coolbox/core/frame/frame.py
@@ -137,7 +137,17 @@ class Frame(FrameBase):
         heights = []
         for track in self.tracks.values():
             if hasattr(track, 'get_track_height'):
-                frame_width = self.properties['width'] * self.properties['width_ratios'][1]
+                # The actual width is given by multiplying:
+                # - the actual width in units cm/inch
+                # - the fraction of the figure not covered by margins
+                # - the fraction of the grid allotted to the middle column
+                margins = self.properties["margins"]
+                margins_fraction = margins["right"] - margins["left"]
+                frame_width = (
+                    self.properties["width"]
+                    * self.properties["width_ratios"][1]
+                    * margins_fraction
+                )
                 height = track.get_track_height(frame_width, self.current_range)
                 heights.append(height)
             elif 'height' in track.properties:

--- a/coolbox/core/track/hicmat/base.py
+++ b/coolbox/core/track/hicmat/base.py
@@ -54,6 +54,10 @@ class HicMatBase(Track, PlotHiCMat, ProcessHicMat):
     process_func : {callable, str, False}, optional
         Process matrix with a user-defined function(receive a matrix, return a processed matrix). default False.
 
+    aspect_ratio : {'equal', 'auto'}, optional
+        When set to 'equal', it ensures that matrix pixels are actually squares. When set to 'auto', it allows
+        matrix pixels to be stretched to completely fill the subplot. Ignored when height parameter is
+        provided. default 'equal'.
 
     """
 
@@ -77,6 +81,7 @@ class HicMatBase(Track, PlotHiCMat, ProcessHicMat):
         'height': 'hic_auto',
         'cmap': "JuiceBoxLike",
         "color_bar": "vertical",
+        "aspect_ratio": "equal",
         "max_value": "auto",
         "min_value": "auto",
         "depth_ratio": DEPTH_FULL,

--- a/coolbox/core/track/hicmat/plot.py
+++ b/coolbox/core/track/hicmat/plot.py
@@ -58,6 +58,11 @@ class PlotHiCMat(object):
         ax = self.ax
         arr = self.matrix
         c_min, c_max = self.matrix_val_range
+
+        aspect = self.properties['aspect_ratio']
+        if self.properties.get('height'):
+            aspect = 'auto'
+
         if gr2 is None and self.style == self.STYLE_TRIANGULAR:
             # triangular style
             scale_r = 1 / math.sqrt(2)
@@ -71,7 +76,7 @@ class PlotHiCMat(object):
             img = ax.matshow(arr, cmap=cmap,
                              transform=tr + ax.transData,
                              extent=(gr.start, gr.end, gr.start, gr.end),
-                             aspect='auto')
+                             aspect=aspect)
         elif gr2 is None and self.style == self.STYLE_WINDOW:
             # window style
             # exist in HicMatBase
@@ -88,14 +93,14 @@ class PlotHiCMat(object):
             img = ax.matshow(arr, cmap=cmap,
                              transform=tr + ax.transData,
                              extent=(gr.start, gr.end, gr.start, gr.end),
-                             aspect='auto')
+                             aspect=aspect)
         else:
             if gr2 is None:
                 gr2 = gr
             # matrix style
             img = ax.matshow(arr, cmap=cmap,
                              extent=(gr.start, gr.end, gr2.end, gr2.start),
-                             aspect='auto')
+                             aspect=aspect)
 
         if self.norm == 'log':
             img.set_norm(colors.LogNorm(vmin=c_min, vmax=c_max))
@@ -192,7 +197,8 @@ class PlotHiCMat(object):
             height = height * self.properties['depth_ratio']
 
         if 'color_bar' in self.properties and self.properties['color_bar'] != 'no':
-            height += 1.5
+            if self.properties["aspect_ratio"] != 'equal':
+                height += 1.5
 
         return height
 


### PR DESCRIPTION
Allow to select aspect ratio of classes inheriting from HicMatBase in order to achieve clearer plotting. Set default to equal aspect ratio. Fixed imprecision in plot width computation.