### PR TITLE
Bug fix in matrix-style tracks height computation and fixed CI

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -32,7 +32,7 @@ jobs:
         $CONDA/bin/conda install -c conda-forge --yes pytest-tornasync
         $CONDA/bin/pytest --cov=./ tests/ --cov-report=xml
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -32,8 +32,7 @@ jobs:
         $CONDA/bin/conda install -c conda-forge --yes pytest-tornasync
         $CONDA/bin/pytest --cov=./ tests/ --cov-report=xml
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v6
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt install libcurl4-openssl-dev
         $CONDA/bin/conda env update --name base --file environment.yml
         $CONDA/bin/pip install .
-        $CONDA/bin/pip install pytest-cov
+        $CONDA/bin/conda install pytest-cov
     - name: Test with pytest
       run: |
         export PATH=$CONDA/bin:$PATH

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -34,6 +34,6 @@ jobs:
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1
       with:
-      	token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -34,5 +34,6 @@ jobs:
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v1
       with:
+      	token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -23,11 +23,12 @@ jobs:
         sudo apt install libcurl4-openssl-dev
         $CONDA/bin/conda env update --name base --file environment.yml
         $CONDA/bin/pip install .
-        $CONDA/bin/conda install pytest-cov
+        $CONDA/bin/pip install pytest-cov
     - name: Test with pytest
       run: |
         export PATH=$CONDA/bin:$PATH
         $CONDA/bin/conda install --yes pytest
+        $CONDA/bin/conda install -c conda-forge sqlite
         $CONDA/bin/conda install -c conda-forge --yes pytest-tornasync
         $CONDA/bin/pytest --cov=./ tests/ --cov-report=xml
     - name: "Upload coverage to Codecov"

--- a/coolbox/core/track/hicmat/plot.py
+++ b/coolbox/core/track/hicmat/plot.py
@@ -187,7 +187,7 @@ class PlotHiCMat(object):
             else:
                 height = frame_width * 0.5
         else:
-            height = frame_width * 0.8
+            height = frame_width
 
         if (
             'depth_ratio' in self.properties


### PR DESCRIPTION
When using style=matrix, PlotHicMat.get_track_height still multiplied track height by 0.8. This was probably the previous way of getting a roughly equal aspect ratio of the matrix since margins were not kept into account in frame width computation. Now that frame width computation is fixed, it actually breaks the aspect ratio.

Likely caused by me forgetting to remove the multiplier when frame width computation formula was fixed.