### PR TITLE
Improve bigwig plot by keep value on the whole interval instead of connect interval middle points.

### DIFF
--- a/coolbox/core/track/hist/bigwig.py
+++ b/coolbox/core/track/hist/bigwig.py
@@ -40,9 +40,13 @@ class BigWig(HistBase):
 
     def fetch_plot_data(self, gr: GenomeRange, **kwargs):
         intervals = self.fetch_data(gr, **kwargs)
-        starts = intervals['start'].values
-        ends = intervals['end'].values
-        positions = (starts + ends) / 2  # use interval midpoints as real genomic coordinates
+        intervals = intervals.melt(
+            id_vars="value",
+            value_vars=["start", "end"],
+            var_name="se",
+            value_name="position"
+        ).sort_values(by=["index", "se"])
+        positions = intervals["position"].values
         values = intervals['value'].values
         return positions, values
 


### PR DESCRIPTION
Current `BigWig.fetch_plot_data` connect values at middle points of bigwig intervals. This causes problem if there is a large interval with 0 value. There will be a very long slope. I improve this by repeating the value at both the start and end of the interval so that the whole interval takes the same value.
