### PR TITLE
Fix `labels = 'on'` should be `labels = True`.

### DIFF
--- a/coolbox/core/track/bed/plot.py
+++ b/coolbox/core/track/bed/plot.py
@@ -22,7 +22,7 @@ class PlotGenes(object):
         self.len_w = None  # this is the length of the letter 'w' given the font size
         self.counter = None
         self.small_relative = None
-        self.is_draw_labels = properties['labels'] == 'on'
+        self.is_draw_labels = None
         self.fp = font_manager.FontProperties(size=properties['fontsize'])
         self.row_scale = properties['interval_height'] * 2.3
         self.cache_gr = None
@@ -62,6 +62,8 @@ class PlotGenes(object):
                 self.is_draw_labels = False
             else:
                 self.is_draw_labels = True
+        else:
+            self.is_draw_labels = properties['labels']
         self.small_relative = 0.004 * (gr.end - gr.start)
         self.counter = 0
 


### PR DESCRIPTION
This fix issue #119 . PlotGenes set `self.is_draw_labels = properties['labels'] == 'on'`. This is not consisent with its dostring which says that `labels` can have values of `True, False, 'auto'`. Also, `PlotGenes` set `self.is_draw_labels` in both `__init__` and `__set_plot_params`. Now I move all settings of `self.is_draw_labels` to the same place (`__set_plot_params`).
