### PR TITLE
Make Feature like Inverted also update the appended coverages of the targeted Track.

### DIFF
--- a/coolbox/core/frame/base.py
+++ b/coolbox/core/frame/base.py
@@ -269,6 +269,11 @@ class FrameBase(abc.ABC):
             if len(result.tracks) != 0:
                 last = list(result.tracks.values())[-1]
                 last.properties.update(other.properties)
+                if hasattr(last, 'coverages'):
+                    for coverage in last.coverages:
+                        coverage.properties.update(other.properties)
+                        if hasattr(coverage, "track_instance"):
+                            coverage.track_instance.properties.update(other.properties)
             return result
         elif isinstance(other, Coverage):
             if len(result.tracks) != 0:


### PR DESCRIPTION
This fix #121. For a frame as `Track() + Coverage() + Feature()`, the feature only updates the properties of the track but not those of the coverage. For a feature like `orientation='inverted'`, the coverage draws after the track, which make the `Inverted` feature not working.
