### PR TITLE
Handle KeyError in TabFileReaderWithOxbow.query().

### DIFF
--- a/coolbox/utilities/reader/tab.py
+++ b/coolbox/utilities/reader/tab.py
@@ -298,7 +298,7 @@ class TabFileReaderWithOxbow(TabFileReader):
                 if 'attributes' in df.columns:
                     df['attributes'] = df['attributes'].apply(_dict_to_gtf_attr)
             df = _convert_dtype(df)
-        except ValueError as e:
+        except (ValueError, KeyError) as e:
             # empty region
             log.error(str(e))
             df = pd.DataFrame(columns=self.columns)


### PR DESCRIPTION
`TabFileReader.query_var_chr` will try `gr.change_chrom_names()` if the original `gr` cannot find maps in the given region. This may cause a query of non-existing chrom, thereby raising `KeyError`. `TabFileReaderWithOxbow.query` only handle `ValueError` but not `KeyError`.
